### PR TITLE
Added Configuration Version Support

### DIFF
--- a/examples/configuration_versions.py
+++ b/examples/configuration_versions.py
@@ -1,0 +1,25 @@
+import pyterprise
+
+tfe_token = 'TOKENHERE'
+client = pyterprise.Client()
+
+# Supply your token as a parameter and the url for the terraform enterprise server.
+# If you are not self hosting, use the one provided by hashicorp.
+client.init(token=tfe_token, url='https://example-host.com')
+
+org = client.set_organization(id='my-organization-name')
+workspace = org.get_workspace('my-test-workspace')
+
+# Get all configuration versions for this workspace
+print(workspace.configuration_versions())
+
+# Create a new configuration version
+config = workspace.create_configuration_version(
+    auto_queue_runs=True,
+    speculative=True
+)
+
+print(config)
+
+# Get a specific configuration version
+print(client.get_configuration_version('cv-Y4aZPkaR7Yr6PwUb'))

--- a/pyterprise/client.py
+++ b/pyterprise/client.py
@@ -73,7 +73,7 @@ class Client():
         return self._api_handler.call(method='delete',
                                       uri=f"organizations/{name}")
 
-    def get_configuration(self, id):
+    def get_configuration_version(self, id):
         """ Returns a specific configuration version. """
         response = self._api_handler.call(uri=f'configuration-versions/{id}')
         return ConfigurationVersion(configuration=object_helper(response.data),

--- a/pyterprise/client.py
+++ b/pyterprise/client.py
@@ -1,7 +1,7 @@
 from .handler import APICaller
 from ._api_response_object import object_helper
 from .organization import Organization
-
+from .configuration_version import ConfigurationVersion
 
 class Client():
     """
@@ -72,3 +72,9 @@ class Client():
     def destroy_organization(self, name):
         return self._api_handler.call(method='delete',
                                       uri=f"organizations/{name}")
+
+    def get_configuration(self, id):
+        """ Returns a specific configuration version. """
+        response = self._api_handler.call(uri=f'configuration-versions/{id}')
+        return ConfigurationVersion(configuration=object_helper(response.data),
+                            api_handler=self._api_handler)

--- a/pyterprise/configuration_version.py
+++ b/pyterprise/configuration_version.py
@@ -1,0 +1,18 @@
+class ConfigurationVersion(object):
+
+    def __init__(self, configuration, api_handler):
+        self._api_handler = api_handler
+
+        self.id = configuration.id
+
+        attributes = configuration.attributes
+        self.auto_queue_runs = attributes.auto_queue_runs
+        self.error = attributes.error
+        self.error_message = attributes.error_message
+        self.source = attributes.source
+        self.status = attributes.status
+        self.status_timestamps = attributes.status_timestamps
+        self.changed_files = attributes.changed_files
+
+    def __str__(self):
+        return str(self.__dict__)

--- a/pyterprise/workspace.py
+++ b/pyterprise/workspace.py
@@ -256,3 +256,20 @@ class Workspace(object):
             runs.append(
                 Run(run=object_helper(run), api_handler=self._api_handler))
         return runs
+
+    def configuration_versions(self):
+        versions = self._api_handler.call(uri=f'workspaces/{self.id}/configuration-versions').data
+        return versions
+
+    def create_configuration_version(self, auto_queue_runs=True, speculative=False):
+        payload = {
+            "data": {
+                "type": "vars",
+                "attributes": {
+                    "auto-queue-runs": auto_queue_runs,
+                    "speculative": speculative,
+                }
+            }
+        }
+        return self._api_handler.call(uri=f'workspaces/{self.id}/configuration-versions', method='post',
+                                      json=payload).data


### PR DESCRIPTION
Added resources for:

https://www.terraform.io/docs/cloud/api/configuration-versions.html#upload-configuration-files

Truly awful implementation from Hashicorp, but is required to create plan runs that don't require discarding. 
